### PR TITLE
Update joi

### DIFF
--- a/lib/schema/definition.js
+++ b/lib/schema/definition.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var Joi = require('joi')
+var Joi = require('@hapi/joi')
 
 module.exports = Joi.object({
   $: Joi.func().required(),

--- a/lib/schema/options.js
+++ b/lib/schema/options.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var Joi = require('joi')
+var Joi = require('@hapi/joi')
 var PluginNoName = Joi.object({
   validate: Joi.func().required(),
   augment: Joi.func(),

--- a/lib/schema/plugin.js
+++ b/lib/schema/plugin.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var Joi = require('joi')
+var Joi = require('@hapi/joi')
 
 module.exports = Joi.object({
   name: Joi.string().required(),

--- a/lib/validate/index.js
+++ b/lib/validate/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var Joi = require('joi')
+var Joi = require('@hapi/joi')
 
 module.exports = function (schema) {
   return function (data) {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "standard": "^11.0.1"
   },
   "dependencies": {
-    "joi": "^13.4.0"
+    "@hapi/joi": "^15.1.0"
   }
 }

--- a/plugin/_util/argValidator.js
+++ b/plugin/_util/argValidator.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var Joi = require('joi')
+var Joi = require('@hapi/joi')
 
 module.exports = function createArgValidator (method) {
   var firstCall = true

--- a/plugin/args/index.js
+++ b/plugin/args/index.js
@@ -2,7 +2,7 @@
 
 var validate = require('../../lib/validate')
 var clone = Array.prototype.slice
-var Joi = require('joi')
+var Joi = require('@hapi/joi')
 var createArgValidator = require('../_util/argValidator')
 
 module.exports = {

--- a/plugin/assert/index.js
+++ b/plugin/assert/index.js
@@ -2,7 +2,7 @@
 
 var validate = require('../../lib/validate')
 var clone = Array.prototype.slice
-var Joi = require('joi')
+var Joi = require('@hapi/joi')
 var createArgValidator = require('../_util/argValidator')
 
 module.exports = {

--- a/plugin/async/index.js
+++ b/plugin/async/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var validate = require('../../lib/validate')
-var Joi = require('joi')
+var Joi = require('@hapi/joi')
 
 module.exports = {
   name: 'async',

--- a/test/args/index.js
+++ b/test/args/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var expect = require('chai').expect
-var joi = require('joi')
+var joi = require('@hapi/joi')
 var explicit = require('../..')
 var validate = require('../../lib/validate')
 

--- a/test/assert/index.js
+++ b/test/assert/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var joi = require('joi')
+var joi = require('@hapi/joi')
 var explicit = require('../../')
 
 function noop () {


### PR DESCRIPTION
Currently npm spits out a bunch of deprecation warnings about joi moving. By updating, those warnings go away.